### PR TITLE
Add MIT License to repository

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2024 Awesome Notifications Guide
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.MD
+++ b/README.MD
@@ -12,6 +12,8 @@ A comprehensive collection of interview questions for Flutter developers, rangin
     - [📋 Topics Covered](#-topics-covered)
       - [Flutter Questions and Answers](#flutter-questions-and-answers)
       - [OOP Questions And Answers](#oop-questions-and-answers)
+    - [📝 License](#-license)
+    - [🤝 Contributing](#-contributing)
     - [Quote](#quote)
 
 ### 🎯 About
@@ -55,6 +57,14 @@ This repository is designed to help developers prepare for interviews. It contai
 Each topic is contained in its own directory with a `questions.md` and `answers.md` file, making it easy to focus on specific areas or review comprehensively.
 
 ---
+
+### 📝 License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+### 🤝 Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
 
 ### Quote
 


### PR DESCRIPTION
This pull request adds the MIT License to the repository, allowing users and contributors to freely use, modify, distribute, and sublicense the software under the conditions outlined in the license. The license provides clear terms for use and also includes a disclaimer of warranty, limiting the liability of the authors.

Key changes:
- Added `LICENSE` file with the MIT License text.
- Updated repository to include the copyright details for the software.

Please review and merge if everything looks good.
